### PR TITLE
fix: 🐛 추가 Cookie 파싱시 null값 체크

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/repository/CookieManager.java
+++ b/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/repository/CookieManager.java
@@ -1,6 +1,7 @@
 package store.cookshoong.www.cookshoongfrontend.auth.repository;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -24,6 +25,9 @@ public interface CookieManager {
      * @return the optional
      */
     default Optional<Cookie> extractCookieByName(HttpServletRequest request, String name) {
+        if (Objects.isNull(request.getCookies())) {
+            return Optional.empty();
+        }
         return Arrays.stream(request.getCookies())
             .filter(cookie -> cookie.getName().equals(name))
             .findAny();


### PR DESCRIPTION
클라이언트가 가지고 있는 Cookie가 아예 없을 경우를 체크해주었습니다.