### PR TITLE
fix: 🐛 추가 세션 만료시 로그아웃 이슈 해결

### DIFF
--- a/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/config/WebSecurityConfig.java
+++ b/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/config/WebSecurityConfig.java
@@ -113,7 +113,7 @@ public class WebSecurityConfig {
         http.addFilterAfter(dormancyAccountFilter, SwitchUserFilter.class);
 
         http.csrf()
-            .ignoringAntMatchers("/delivery", "/actuator/loggers/**");
+            .ignoringAntMatchers("/delivery", "/actuator/loggers/**", "/logout");
 
         http.exceptionHandling()
             .accessDeniedHandler(forbiddenAccessHandler);

--- a/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/hanlder/TokenInvalidationHandler.java
+++ b/src/main/java/store/cookshoong/www/cookshoongfrontend/auth/hanlder/TokenInvalidationHandler.java
@@ -1,5 +1,6 @@
 package store.cookshoong.www.cookshoongfrontend.auth.hanlder;
 
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,13 @@ public class TokenInvalidationHandler implements LogoutHandler {
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        if (isAlreadyLogout(request)) {
+            return;
+        }
         authApiAdapter.executeTokenInvalidated();
+    }
+
+    public boolean isAlreadyLogout(HttpServletRequest request) {
+        return Objects.isNull(request.getUserPrincipal()) || Objects.isNull(request.getUserPrincipal().getName());
     }
 }


### PR DESCRIPTION
세션 만료시 CSRF 토큰이 제대로 보내지지 않는 이슈가 있어 우선 csrf에서 제외시켰습니다. 세션 만료시 액세스토큰을 갖지 않기에 해당 사항을 토큰 무효화 로직에서 빼줬습니다.